### PR TITLE
avm2: Remove `run_frame_avm2` and FramePhase::Update

### DIFF
--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -444,10 +444,10 @@ impl<'gc> Avm1<'gc> {
         // Remove pending objects
         Self::remove_pending(context);
 
-        // In AVM1, we only ever execute the update phase, and all the work that
+        // In AVM1, we only ever execute the idle phase, and all the work that
         // would ordinarily be phased is instead run all at once in whatever order
         // the SWF requests it.
-        *context.frame_phase = FramePhase::Update;
+        *context.frame_phase = FramePhase::Idle;
 
         // AVM1 execution order is determined by the global execution list, based on instantiation order.
         let mut prev: Option<DisplayObject<'gc>> = None;
@@ -463,7 +463,7 @@ impl<'gc> Avm1<'gc> {
                 }
                 clip.set_next_avm1_clip(context.gc_context, None);
             } else {
-                clip.run_frame(context);
+                clip.run_frame_avm1(context);
                 prev = Some(clip);
             }
         }

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1371,22 +1371,7 @@ pub trait TDisplayObject<'gc>:
     }
 
     /// Execute all other timeline actions on this object.
-    fn run_frame(&self, _context: &mut UpdateContext<'_, 'gc>) {}
-
-    /// Execute all other timeline actions on this object and it's children.
-    ///
-    /// AVM2 operates recursively through children, so this also instructs
-    /// children to run a frame.
-    fn run_frame_avm2(&self, context: &mut UpdateContext<'_, 'gc>) {
-        // Children run first.
-        if let Some(container) = self.as_container() {
-            for child in container.iter_render_list() {
-                child.run_frame_avm2(context);
-            }
-        }
-
-        self.run_frame(context);
-    }
+    fn run_frame_avm1(&self, _context: &mut UpdateContext<'_, 'gc>) {}
 
     /// Emit a `frameConstructed` event on this DisplayObject and any children it
     /// may have.
@@ -1640,8 +1625,8 @@ pub trait TDisplayObject<'gc>:
         _instantiated_by: Instantiator,
         run_frame: bool,
     ) {
-        if run_frame {
-            self.run_frame(context);
+        if run_frame && !context.is_action_script_3() {
+            self.run_frame_avm1(context);
         }
     }
 

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -196,7 +196,7 @@ impl<'gc> Avm1Button<'gc> {
         for (child, depth) in children {
             // Initialize new child.
             child.post_instantiation(context, None, Instantiator::Movie, false);
-            child.run_frame(context);
+            child.run_frame_avm1(context);
             let removed_child = self.replace_at_depth(context, child, depth.into());
             dispatch_added_event(self.into(), child, false, context);
             if let Some(removed_child) = removed_child {
@@ -277,12 +277,12 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
             drop(mc);
 
             if run_frame {
-                self.run_frame(context);
+                self.run_frame_avm1(context);
             }
         }
     }
 
-    fn run_frame(&self, context: &mut UpdateContext<'_, 'gc>) {
+    fn run_frame_avm1(&self, context: &mut UpdateContext<'_, 'gc>) {
         let self_display_object = (*self).into();
         let initialized = self.0.read().initialized;
 

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -348,10 +348,6 @@ impl<'gc> Avm2Button<'gc> {
             }
         }
 
-        if let Some(child) = child {
-            child.run_frame_avm2(context);
-        }
-
         if is_cur_state {
             if let Some(child) = child {
                 child.run_frame_scripts(context);
@@ -426,13 +422,9 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
         context: &mut UpdateContext<'_, 'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
-        run_frame: bool,
+        _run_frame: bool,
     ) {
         self.set_default_instance_name(context);
-
-        if run_frame {
-            self.run_frame_avm2(context);
-        }
     }
 
     fn enter_frame(&self, context: &mut UpdateContext<'_, 'gc>) {
@@ -555,13 +547,6 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
 
                 self.set_state(context, ButtonState::Up);
 
-                //NOTE: Yes, we do have to run these in a different order from the
-                //regular run_frame method.
-                up_state.run_frame_avm2(context);
-                over_state.run_frame_avm2(context);
-                down_state.run_frame_avm2(context);
-                hit_area.run_frame_avm2(context);
-
                 up_state.run_frame_scripts(context);
                 over_state.run_frame_scripts(context);
                 down_state.run_frame_scripts(context);
@@ -585,33 +570,6 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
                     tracing::error!("Got {} when constructing AVM2 side of button", e);
                 }
             }
-        }
-    }
-
-    fn run_frame_avm2(&self, context: &mut UpdateContext<'_, 'gc>) {
-        if self.0.read().skip_current_frame {
-            self.0.write(context.gc_context).skip_current_frame = false;
-            return;
-        }
-
-        let hit_area = self.0.read().hit_area;
-        if let Some(hit_area) = hit_area {
-            hit_area.run_frame_avm2(context);
-        }
-
-        let up_state = self.0.read().up_state;
-        if let Some(up_state) = up_state {
-            up_state.run_frame_avm2(context);
-        }
-
-        let down_state = self.0.read().down_state;
-        if let Some(down_state) = down_state {
-            down_state.run_frame_avm2(context);
-        }
-
-        let over_state = self.0.read().over_state;
-        if let Some(over_state) = over_state {
-            over_state.run_frame_avm2(context);
         }
     }
 

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -279,10 +279,10 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
             context
                 .avm1
                 .add_to_exec_list(context.gc_context, (*self).into());
-        }
 
-        if run_frame {
-            self.run_frame(context);
+            if run_frame {
+                self.run_frame_avm1(context);
+            }
         }
     }
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1379,7 +1379,7 @@ impl<'gc> EditText<'gc> {
         });
 
         if run_frame {
-            self.run_frame(context);
+            self.run_frame_avm1(context);
         }
     }
 
@@ -1514,7 +1514,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         }
     }
 
-    fn run_frame(&self, _context: &mut UpdateContext) {
+    fn run_frame_avm1(&self, _context: &mut UpdateContext) {
         // Noop
     }
 

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -178,7 +178,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         }
     }
 
-    fn run_frame(&self, _context: &mut UpdateContext) {
+    fn run_frame_avm1(&self, _context: &mut UpdateContext) {
         // Noop
     }
 
@@ -233,10 +233,10 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
             context
                 .avm1
                 .add_to_exec_list(context.gc_context, (*self).into());
-        }
 
-        if run_frame {
-            self.run_frame(context);
+            if run_frame {
+                self.run_frame_avm1(context);
+            }
         }
     }
 

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -94,7 +94,7 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
         }
     }
 
-    fn run_frame(&self, _context: &mut UpdateContext) {
+    fn run_frame_avm1(&self, _context: &mut UpdateContext) {
         // Noop
     }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1578,7 +1578,7 @@ impl<'gc> MovieClip<'gc> {
                     // In AVM2 we add them in `construct_frame` so calling this causes
                     // duplicate frames
                     if !movie.is_action_script_3() {
-                        child.run_frame(context);
+                        child.run_frame_avm1(context);
                     }
                 }
 
@@ -1970,7 +1970,7 @@ impl<'gc> MovieClip<'gc> {
                     self.0.write(activation.context.gc_context).object = Some(object.into());
 
                     if run_frame {
-                        self.run_frame(&mut activation.context);
+                        self.run_frame_avm1(&mut activation.context);
                     }
 
                     if let Some(init_object) = init_object {
@@ -1997,7 +1997,7 @@ impl<'gc> MovieClip<'gc> {
             self.0.write(context.gc_context).object = Some(object.into());
 
             if run_frame {
-                self.run_frame(context);
+                self.run_frame_avm1(context);
             }
 
             if let Some(init_object) = init_object {
@@ -2045,7 +2045,7 @@ impl<'gc> MovieClip<'gc> {
                 false,
             );
         } else if run_frame {
-            self.run_frame(context);
+            self.run_frame_avm1(context);
         }
 
         // If this text field has a variable set, initialize text field binding.
@@ -2415,7 +2415,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         }
     }
 
-    fn run_frame(&self, context: &mut UpdateContext<'_, 'gc>) {
+    fn run_frame_avm1(&self, context: &mut UpdateContext<'_, 'gc>) {
         if !context.is_action_script_3() {
             // Run my load/enterFrame clip event.
             let is_load_frame = !self.0.read().flags.contains(MovieClipFlags::INITIALIZED);

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -107,7 +107,7 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
         }
     }
 
-    fn run_frame(&self, _context: &mut UpdateContext) {
+    fn run_frame_avm1(&self, _context: &mut UpdateContext) {
         // Noop
     }
 

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -393,8 +393,8 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
 
         self.seek(context, starting_seek);
 
-        if run_frame {
-            self.run_frame(context);
+        if !context.is_action_script_3() && run_frame {
+            self.run_frame_avm1(context);
         }
     }
 


### PR DESCRIPTION
These were unused for all AVM2 objects.
I've renamed the `run_frame` method to `run_frame_avm1`, as it's only used for AVM1-specific logic.